### PR TITLE
[Feat] print generated credentials

### DIFF
--- a/charts/s3gw/templates/NOTES.txt
+++ b/charts/s3gw/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Thank you for installing {{ .Chart.Name }} {{ printf "v%s" .Chart.Version }}
+
+The S3 endpoint is available at:
+
+{{ printf "%s.%s" .Values.serviceName .Values.publicDomain | indent 4 }}
+{{ if .Values.ui.enabled}}
+and the web interface is available at:
+
+{{ printf "%s.%s" .Values.ui.serviceName .Values.ui.publicDomain | indent 4 }}
+{{- end }}
+{{ if and (not .Values.useExistingSecret) (empty .Values.accessKey) }}
+An access key has been generated: {{ include "s3gw.defaultAccessKey" . | quote }}
+{{- end }}
+{{- if and (not .Values.useExistingSecret) (empty .Values.secretKey) }}
+A secret key has been generated: {{ include "s3gw.defaultSecretKey" . | quote }}
+{{ end }}

--- a/charts/s3gw/templates/_helpers.tpl
+++ b/charts/s3gw/templates/_helpers.tpl
@@ -97,3 +97,16 @@ Image Pull Secret
 {{- $au := (printf "%s:%s" $un $pw | b64enc) }}
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" $rg $un $pw $em $au | b64enc}}
 {{- end }}
+
+
+{{/*
+Default Access Credentials
+*/}}
+{{- define "s3gw.defaultAccessKey" -}}
+{{- $key := default (randAlphaNum 32) .Values.accessKey }}
+{{- printf "%s" $key }}
+{{- end }}
+{{- define "s3gw.defaultSecretKey" -}}
+{{- $key := default (randAlphaNum 32) .Values.secretKey }}
+{{- printf "%s" $key }}
+{{- end }}

--- a/charts/s3gw/templates/secret.yaml
+++ b/charts/s3gw/templates/secret.yaml
@@ -9,8 +9,8 @@ metadata:
 {{ include "s3gw.labels" . | indent 4 }}
 type: Opaque
 stringData:
-  RGW_DEFAULT_USER_ACCESS_KEY: {{ ternary (randAlphaNum 32) (.Values.accessKey) (empty .Values.accessKey) }}
-  RGW_DEFAULT_USER_SECRET_KEY: {{ ternary (randAlphaNum 32) (.Values.secretKey) (empty .Values.secretKey) }}
+  RGW_DEFAULT_USER_ACCESS_KEY: {{ include "s3gw.defaultAccessKey" . | quote }}
+  RGW_DEFAULT_USER_SECRET_KEY: {{ include "s3gw.defaultSecretKey" . | quote }}
 {{- end }}
 {{- if .Values.imageCredentials }}
 ---


### PR DESCRIPTION

Print the generated credentials to the console after installation. This saves the user from having to fish them out of the thicket of K8s objects after the fact. It also comes with a friendly message telling the user what version was installed and where the S3 and UI endpoints are for convenience.

![print-generated-secrets](https://user-images.githubusercontent.com/17141774/211771338-adf5c717-28d1-44f0-a201-f34e33bef2ff.png)

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
